### PR TITLE
feat(mcp-server): review 体系告别 plan 模式 — yolo+写工具物理禁用 + zcode_security_review (mimosa 预扫)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,13 @@ ZCODE_BASE_URL=https://api.z.ai/api/anthropic ./packages/mcp-server/zcode-mcp-se
 |------|------|
 | `ZCODE_BRIDGE_MIMOSA_ROOT` | 指向 mimosa 插件根目录（含 `payload/dist/mcp/server.js` 的那层）；不设则自动探测 `~/.local/share/mimosa/*` 与 `~/.zcode/cli/plugins/cache/*/mimosa/*`，找不到会明确报错并建议改用 `zcode_review` |
 | `ZCODE_BRIDGE_MIMOSA_TIMEOUT` | mimosa `security_scan` 快扫超时（默认 180s） |
+| `ZCODE_BRIDGE_MIMOSA_SCAN_ROOT` | findings 回读的信任根（默认 `~/.mimosa/security-scans`）：从 mimosa 摘要解析出的 scanDir 必须落在其下才回读 `findings.json`，越界降级为仅用摘要（防路径注入导致任意文件回读） |
 
 > mimosa 的调用不依赖 zcode 插件体系：bridge 用自带极简 stdio MCP client 直接 spawn mimosa 的 `server.js`（env `ZCODE_PLUGIN_ROOT=<root>`、`MIMOSA_ENGINE=native`，cwd=被扫项目）。mimosa 快扫是确定性规则引擎、零 LLM 流量，故不走 review 文件锁。
 >
-> 实测备注（2026-08-08，GC-8G）：① 独立调用时 mimosa 也会在被扫项目写一个小会话状态文件（`.mimosa/hook-state/sess_*.continue.json`，约 200 字节，无害），除此之外 bridge 链路对被扫目录完全只读；② 从非登录 shell（systemd unit、cron、`sudo -u` 直调）启动时 PATH 可能不含 `~/.local/bin`，需显式 `export PATH="$HOME/.local/bin:$PATH"` 否则找不到 `zcode`。
+> 实测备注（2026-08-08，GC-8G）：① 独立调用时 mimosa 也会在被扫项目写一个小会话状态文件（`.mimosa/hook-state/sess_*.continue.json`，约 200 字节，无害）——即 bridge 自身的代码路径对被扫目录只读，但 mimosa 引擎会落这个状态文件，说"完全只读"不准确；② 从非登录 shell（systemd unit、cron、`sudo -u` 直调）启动时 PATH 可能不含 `~/.local/bin`，需显式 `export PATH="$HOME/.local/bin:$PATH"` 否则找不到 `zcode`。
+>
+> 并发与阻塞边界（狗食 review P2-4/P2-5）：mimosa 预扫**不在** review 文件锁内（确定性引擎无 LLM 限流问题），只有 zcode 复核阶段持锁——并发扫同一项目时 mimosa 的 hook-state 文件各写各的会话，无冲突。最坏阻塞时长估算：锁等待 300s + 单次调用 `ZCODE_BRIDGE_REVIEW_TIMEOUT`（默认 300s）×（1 + `ZCODE_BRIDGE_MAX_RETRIES` 默认 3）+ 限流退避，极端情况单次 tool 调用可阻塞约 20 分钟，调用方应把 MCP 超时设到相应量级。
 
 ### 聚焦审查 prompt 建议
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,15 @@ zcode --prompt "继续" --resume sess_xxxx
 
 ### MCP server（`zcode-mcp-server`）
 
-暴露两个 MCP tool：
+暴露三个 MCP tool：
 
 | Tool | 作用 |
 |------|------|
 | `get_zcode_capabilities` | 返回 ZCode 能力清单（调 agent-help） |
-| `zcode_review` | 调 ZCode 审查代码（只读 plan 模式，安全） |
+| `zcode_review` | 调 ZCode 审查代码（yolo + 写/执行工具物理禁用，全程免授权但改不了文件，安全） |
+| `zcode_security_review` | 安全专项审查：mimosa 确定性规则引擎全仓预扫 → ZCode 拿 findings 逐条核实（确认/误报/存疑 + 攻击路径 + 修复建议） |
+
+> **只读原理（2026-08-08 重构，告别 `--mode plan`）**：review 体系不再用 plan 模式——plan 只禁「改文件」，读探索/子代理照样放行（限流超时主因），且 plan→build 的规划惯性容易让 review 变成「边审边修」。新方案用 `--mode yolo`（全程免授权）+ `--disallowed-tools` 把 `Write/Edit/MultiEdit/ApplyPatch/Bash` 连同 Node REPL 一族（`js` / `mcp__node_repl__js*`）一起禁掉：`--disallowed-tools` 是工具集级物理移除、先于权限层，yolo 也绕不过；Node REPL 一族必须同禁，否则可被 `execSync` 打穿 Bash 黑名单（0.16.1 实测复现）。读工具（Read/Grep/Glob）全开，不影响审查能力。prompt 层另有「只审不修」职责约束（不修改文件、不提议帮忙修复）作双保险。
 
 ### ACP bridge（`zcode-acp-bridge`）
 
@@ -233,19 +236,31 @@ ZCODE_BASE_URL=https://api.z.ai/api/anthropic ./packages/mcp-server/zcode-mcp-se
 
 ### 限流与重试（MCP server）
 
-`zcode_review` 调用 headless zcode 做 PR 审查时，多个 gate 并发可能触发 provider 限流。MCP server 做了三层防护（issue #3）：
+`zcode_review` / `zcode_security_review` 调用 headless zcode 做审查时，多个 gate 并发可能触发 provider 限流。MCP server 做了三层防护（issue #3）：
 
 | 机制 | 行为 | 配置 |
 |------|------|------|
 | **进程级文件锁** | 多个 MCP client 并发调用时，串行化 headless review，防并发触发限流 | `ZCODE_BRIDGE_REVIEW_LOCK=0` 关闭 |
 | **provider 错误解析** | 识别 429 / 1302 / `Too Many Requests` / `请求过于频繁` / `retry-after`，区分限流/配额/其他 | — |
 | **有限重试 + 退避** | 仅对**限流**错误重试（配额/Unauthorized 不重试），退避用 retry-after 或指数退避（`2^n+1`） | `ZCODE_BRIDGE_MAX_RETRIES`（默认 3） |
+| **单次调用超时** | review 单次 zcode 调用超时 | `ZCODE_BRIDGE_REVIEW_TIMEOUT`（默认 300s，下限 30s） |
 
 注意：zcode 内部已有自己的指数退避重试（`_retryWithExponentialBackoff`），MCP 层的重试是补充，默认保守（max 3）。
 
+`zcode_security_review` 额外有 mimosa 相关的两个 env：
+
+| 配置 | 作用 |
+|------|------|
+| `ZCODE_BRIDGE_MIMOSA_ROOT` | 指向 mimosa 插件根目录（含 `payload/dist/mcp/server.js` 的那层）；不设则自动探测 `~/.local/share/mimosa/*` 与 `~/.zcode/cli/plugins/cache/*/mimosa/*`，找不到会明确报错并建议改用 `zcode_review` |
+| `ZCODE_BRIDGE_MIMOSA_TIMEOUT` | mimosa `security_scan` 快扫超时（默认 180s） |
+
+> mimosa 的调用不依赖 zcode 插件体系：bridge 用自带极简 stdio MCP client 直接 spawn mimosa 的 `server.js`（env `ZCODE_PLUGIN_ROOT=<root>`、`MIMOSA_ENGINE=native`，cwd=被扫项目）。mimosa 快扫是确定性规则引擎、零 LLM 流量，故不走 review 文件锁。
+>
+> 实测备注（2026-08-08，GC-8G）：① 独立调用时 mimosa 也会在被扫项目写一个小会话状态文件（`.mimosa/hook-state/sess_*.continue.json`，约 200 字节，无害），除此之外 bridge 链路对被扫目录完全只读；② 从非登录 shell（systemd unit、cron、`sudo -u` 直调）启动时 PATH 可能不含 `~/.local/bin`，需显式 `export PATH="$HOME/.local/bin:$PATH"` 否则找不到 `zcode`。
+
 ### 聚焦审查 prompt 建议
 
-为降低限流风险，自动化审查时建议：把 diff/证据作为 `--attach` 附件，prompt 写明"不要 spawn 子代理、不要探索文件系统、只基于附件推理"。
+`zcode_review` / `zcode_security_review` 两个 MCP tool 已把这条纪律内化：prompt 内置「只审不修」职责约束（不修改文件、不提议帮忙修复、只用只读工具读上下文），写/执行工具在工具集层物理禁用，且证据统一走 `--attach` 附件。若绕过 tool 直接手写 CLI 做自动化审查，仍建议自己加上同款约束：把 diff/证据作为 `--attach` 附件，prompt 写明"不要 spawn 子代理、不要探索文件系统、只基于附件推理"，以降低限流风险。
 
 ## 版本兼容性
 

--- a/docs/upgrade-0.16.1-spec.md
+++ b/docs/upgrade-0.16.1-spec.md
@@ -155,3 +155,12 @@
 ### §2 存活清单补记
 
 - `session/updateRuntimeModelConfig`：commander 实测 0.16.1 仍存活，但 schema 新要求 `runtimeModel.revision`（string）必填。
+
+### headless CLI 参数与权限模式勘误（2026-08-08 review 重构实测）
+
+以下来自 0.16.1 headless 实测（逆向 bundle + 运行验证），触发背景是 MCP server review 体系从 `--mode plan` 重构为「yolo + 写工具物理禁用」：
+
+- **`--allowed-tools` / `--max-turns` 帮助文案有、但未注册 parseArgs**：调用直接报 `Unknown option`，不可用；白名单方向只有 `--disallowed-tools` 可用。
+- **`auto` 权限模式是保留值未实现**：`session/setMode` 切到 `auto` 会导致工具调用全拒，勿用。
+- **headless 下 build/edit 的写操作不是「等授权」而是直接失败**：报 `No permission client configured`。所以自动化场景要么 yolo 全程免授权，要么用 `--disallowed-tools` 物理收权，不存在「build 模式等确认」这条中间路。
+- 附带实证：`--disallowed-tools` 是工具集级物理移除，先于权限层，`--mode yolo` 也绕不过；但必须连 Node REPL 一族（`js` / `mcp__node_repl__js*`）一起禁，否则模型可用 `execSync` 等价执行任意命令打穿 Bash 黑名单（实测复现）。

--- a/packages/agent-help/zcode-agent-help
+++ b/packages/agent-help/zcode-agent-help
@@ -261,11 +261,13 @@ NATIVE_CLI = {
         {"category": "permission", "name": "mode", "supported": True,
          "description": "权限模式: 控制 zcode 自主权", "arg": "--mode <mode>",
          "values": {
-             "plan": "只读规划, 不改文件 (最安全, 适合 review)",
-             "build": "可读可写, 关键操作确认",
+             "plan": "只读规划, 不改文件 (但读探索/子代理仍放行)",
+             "build": "可读可写, 关键操作确认 (headless 下写操作直接失败: No permission client)",
              "edit": "可编辑文件",
              "yolo": "全自动, 跳过确认 (--prompt 默认)",
          },
+         "note": "0.16.1 headless 仅接受 build/edit/plan/yolo; auto 是 app-server schema "
+                 "保留值未实现 (setMode 切 auto 会全拒工具调用, mode.auto.unimplemented)",
          "example": "zcode --prompt \"review\" --mode plan"},
         # 浏览器
         {"category": "browser", "name": "browser-use", "supported": True,
@@ -292,25 +294,25 @@ NATIVE_CLI = {
         # 自主性
         {"category": "agency", "name": "autonomous-tools", "supported": True,
          "description": "自主调用工具: 读写文件、Bash、Grep、Web 搜索等",
-         "limitations": {"tool_allowlist": "0.16.1+ 支持 (--allowed-tools)",
-                         "tool_denylist": "0.16.1+ 支持 (--disallowed-tools)",
-                         "max_turns": "0.16.1+ 支持 (--max-turns)",
+         "limitations": {"tool_allowlist": "0.16.1 帮助文案宣称 --allowed-tools, 实测未注册 parseArgs (Unknown option)",
+                         "tool_denylist": "0.16.1+ 实测可用 (--disallowed-tools, 工具集级物理移除, yolo 也绕不过)",
+                         "max_turns": "0.16.1 帮助文案宣称 --max-turns, 实测未注册 parseArgs (Unknown option)",
                          "max_budget": "不支持"}},
-        {"category": "agency", "name": "tool-allowlist", "supported": True,
-         "description": "工具白名单: 仅允许列出的工具 (逗号/空格分隔, 仅 headless prompt)",
+        {"category": "agency", "name": "tool-allowlist", "supported": False,
+         "description": "工具白名单 — 帮助文案有但 0.16.1 未接线 (实测 Unknown option), 勿用",
          "arg": "--allowed-tools <list>",
-         "example": "zcode --prompt \"review\" --allowed-tools \"Read Grep\"",
-         "since": "0.16.1"},
+         "since": "0.16.1 (仅文案)"},
         {"category": "agency", "name": "tool-denylist", "supported": True,
-         "description": "工具黑名单: 禁止列出的工具 (逗号/空格分隔; camelCase 别名 --disallowedTools)",
+         "description": "工具黑名单: 禁止列出的工具 (逗号/空格分隔; camelCase 别名 --disallowedTools)。"
+                        "实测确认: 工具集级物理移除, 先于权限层, yolo 也绕不过;"
+                        "禁 Bash 时必须连 js / mcp__node_repl__js* 一族同禁, 否则可被 execSync 打穿",
          "arg": "--disallowed-tools <list>",
          "example": "zcode --prompt \"整理代码\" --disallowed-tools \"Bash(git *) Edit\"",
          "since": "0.16.1"},
-        {"category": "agency", "name": "max-turns", "supported": True,
-         "description": "限制 headless prompt 的最大模型轮次",
+        {"category": "agency", "name": "max-turns", "supported": False,
+         "description": "最大模型轮次 — 帮助文案有但 0.16.1 未接线 (实测 Unknown option), 勿用",
          "arg": "--max-turns <n>",
-         "example": "zcode --prompt \"修掉这个 bug\" --max-turns 20",
-         "since": "0.16.1"},
+         "since": "0.16.1 (仅文案)"},
     ],
     # 子命令 (zcode <command>, 实测自 0.16.1 --help)
     "subcommands": [
@@ -450,7 +452,9 @@ APP_SERVER = {
         {"method": "session/rewindCascade", "params": "sessionId, target?, scope?, expectedRevision?",
          "note": "❌ 0.16 已移除 (调用返 -32601); 原为 0.15.0+ 级联回退 (与 rewind 同 schema)"},
         {"method": "session/setMode", "params": "sessionId, mode",
-         "note": "0.15.0+ 暴露: 切换会话权限模式 (mode: plan|build|edit|yolo|auto)"},
+         "note": "0.15.0+ 暴露: 切换会话权限模式 (mode: plan|build|edit|yolo|auto); "
+                 "⚠ auto 为保留值未实现 — 切 auto 后该会话所有工具调用被 "
+                 "mode.auto.unimplemented 拒绝, 勿当'智能自动批准'用"},
         # ----- 0.15.0 (App 3.2.0) 新增 workspace/* 方法 (按工作区定位, 非 session) -----
         {"method": "workspace/readState", "params": "workspace:{workspacePath,workspaceKey}, runtimeModel?",
          "note": "0.15.0+: 读工作区状态 (settings/modelCatalog/slashCommands)"},
@@ -516,7 +520,8 @@ ECOSYSTEM = {
             "transport": "MCP over stdio (JSON-RPC 2.0)",
             "tools_exposed": [
                 {"name": "get_zcode_capabilities", "description": "返回 zcode 能力清单 (调 agent-help)"},
-                {"name": "zcode_review", "description": "调 zcode 审查代码 (--mode plan 只读)"},
+                {"name": "zcode_review", "description": "调 zcode 审查代码 (yolo+写工具物理禁用: 免授权只读)"},
+                {"name": "zcode_security_review", "description": "mimosa 规则引擎预扫 + zcode 只读复核 (安全专项)"},
             ],
             "config": "~/.zcode/cli/config.json 的 mcp.servers.zcode-mcp",
             "use_case": "让 MCP client (zcode 自身/Claude Code/Cursor) 标准化调用 zcode",

--- a/packages/mcp-server/zcode-mcp-server
+++ b/packages/mcp-server/zcode-mcp-server
@@ -6,8 +6,9 @@ zcode-mcp-server — 把 headless ZCode 能力暴露为标准 MCP server
 Claude Code、Cursor 等) 能标准化地发现并调用 headless zcode。
 
 暴露的 tools:
-  1. get_zcode_capabilities — 返回 headless zcode 完整能力清单 (JSON)
-  2. zcode_review           — 直接调 zcode 审查代码 (封装 --prompt + --attach + --mode plan)
+  1. get_zcode_capabilities  — 返回 headless zcode 完整能力清单 (JSON)
+  2. zcode_review            — 调 zcode 审查代码 (yolo + 写工具物理禁用, 免授权且只读)
+  3. zcode_security_review   — mimosa 规则引擎预扫 + zcode 只读逐条复核 (安全专项)
 
 协议: MCP over stdio (JSON-RPC 2.0, 每行一条消息)
 日志: 全部走 stderr (绝不污染 stdout 协议流)
@@ -19,6 +20,7 @@ import fcntl
 import json
 import os
 import re
+import select
 import subprocess
 import sys
 import time
@@ -36,7 +38,7 @@ ZCODE_BIN = os.environ.get("ZCODE_BIN", "zcode")
 
 # MCP 协议版本
 PROTOCOL_VERSION = "2024-11-05"
-SERVER_INFO = {"name": "zcode-mcp-server", "version": "1.0.0"}
+SERVER_INFO = {"name": "zcode-mcp-server", "version": "1.1.0"}
 
 
 def log(msg):
@@ -239,6 +241,169 @@ class ReviewFileLock:
 
 
 # ============================================================
+# Review 只读护栏 (2026-08-08 重构: 告别 --mode plan)
+# ------------------------------------------------------------
+# 旧实现用 --mode plan 求"只读", 但 plan 只禁"改文件": 读探索/子代理照样放
+# 行 (限流与超时主因), 且 plan→build 的规划惯性会让 review 顺手变成"边审边修"。
+# 0.16.1 实测结论 (逆向 bundle + headless 验证):
+#   - --disallowed-tools 是工具集级物理移除, 先于权限层, yolo 也绕不过;
+#   - 必须连 Node REPL 一族 (js / mcp__node_repl__js*) 一起禁, 否则模型可
+#     用 execSync 等价执行任意命令打穿 Bash 黑名单 (实测复现);
+#   - --mode yolo 全程免授权; headless 下 build/edit 的写操作不是"等授权"
+#     而是直接报 "No permission client configured" 失败;
+#   - --allowed-tools / --max-turns 帮助文案有, 但未注册 parseArgs (实测
+#     Unknown option), 不可用; auto 模式是保留值未实现。
+# 组合: --mode yolo (免授权) + 全量写/执行黑名单 (物理只读, 读工具全开)。
+# ============================================================
+REVIEW_DISALLOWED_TOOLS = (
+    "Write Edit MultiEdit ApplyPatch Bash "
+    "js js_reset js_add_node_module_dir "
+    "mcp__node_repl__js mcp__node_repl__js_reset mcp__node_repl__js_add_node_module_dir"
+)
+
+
+def _find_mimosa_root():
+    """定位 mimosa 插件根目录 (含 payload/dist/mcp/server.js 的那层)。
+
+    ZCODE_BRIDGE_MIMOSA_ROOT 优先; 否则探测常见安装位 (独立副本 + zcode
+    插件缓存), 同目录多版本取路径排序最大者。找不到返回 None。
+    """
+    env_root = os.environ.get("ZCODE_BRIDGE_MIMOSA_ROOT")
+    candidates = [env_root] if env_root else []
+    home = Path.home()
+    for pat in (".local/share/mimosa/*",
+                ".zcode/cli/plugins/cache/*/mimosa/*"):
+        candidates.extend(str(p) for p in sorted(home.glob(pat), reverse=True))
+    for c in candidates:
+        if c and (Path(c) / "payload" / "dist" / "mcp" / "server.js").exists():
+            return c
+    return None
+
+
+class MimosaMcpClient:
+    """极简 stdio MCP client (JSON-RPC 2.0, 每行一条消息, posix select 超时)。
+
+    用于把 mimosa 插件的 MCP server (payload/dist/mcp/server.js) 当子进程
+    直接调用, 不经过 zcode 插件体系。仅实现 initialize + tools/call。
+    """
+
+    def __init__(self, root, cwd, timeout=120):
+        server_js = Path(root) / "payload" / "dist" / "mcp" / "server.js"
+        if not server_js.exists():
+            raise FileNotFoundError(f"mimosa MCP server 不存在: {server_js}")
+        env = dict(os.environ)
+        env["ZCODE_PLUGIN_ROOT"] = str(root)
+        env.setdefault("MIMOSA_ENGINE", "native")
+        self._proc = subprocess.Popen(
+            ["node", str(server_js)],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, text=True, cwd=cwd, env=env,
+        )
+        self.timeout = timeout
+        self._id = 0
+
+    def _send(self, msg):
+        self._proc.stdin.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        self._proc.stdin.flush()
+
+    def _recv(self):
+        fd = self._proc.stdout.fileno()
+        ready, _, _ = select.select([fd], [], [], self.timeout)
+        if not ready:
+            raise TimeoutError(f"mimosa MCP 响应超时 ({self.timeout}s)")
+        line = self._proc.stdout.readline()
+        if not line:
+            raise RuntimeError("mimosa MCP server 提前退出 (stdout EOF)")
+        return json.loads(line)
+
+    def _request(self, method, params):
+        self._id += 1
+        rid = self._id
+        self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        while True:  # 跳过 notification, 等到 id 匹配的响应
+            resp = self._recv()
+            if resp.get("id") == rid:
+                if "error" in resp:
+                    raise RuntimeError(f"mimosa MCP {method} 错误: {resp['error']}")
+                return resp.get("result", {})
+
+    def initialize(self):
+        self._request("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": SERVER_INFO["name"], "version": SERVER_INFO["version"]},
+        })
+        self._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def call_tool(self, name, arguments):
+        return self._request("tools/call", {"name": name, "arguments": arguments})
+
+    def close(self):
+        try:
+            if self._proc.poll() is None:
+                self._proc.terminate()
+                try:
+                    self._proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._proc.kill()
+        except Exception:
+            pass
+
+
+def _mimosa_quick_scan(root, scan_path):
+    """调 mimosa security_scan (同步快扫), 返回 (摘要文本, findings list)。失败抛异常。
+
+    security_scan 的 MCP 响应只有 Markdown 摘要 (scanId/scanDir/seal/计数),
+    全量 findings 需按摘要里的 scanDir 回读 <scanDir>/findings.json
+    (schemaVersion: mimosa-security-scan-findings/v1)。depth=normal 跳过
+    业务逻辑投研, 秒级; deep 明显更慢, 未接 (需要时应走 start/status 异步对)。
+    """
+    timeout = max(30, _env_int("ZCODE_BRIDGE_MIMOSA_TIMEOUT", 180))
+    client = MimosaMcpClient(root, cwd=scan_path, timeout=timeout)
+    try:
+        client.initialize()
+        result = client.call_tool(
+            "security_scan", {"project": scan_path, "depth": "normal"})
+    finally:
+        client.close()
+    texts = [c.get("text", "") for c in result.get("content", [])
+             if isinstance(c, dict) and c.get("type") == "text"]
+    body = "\n".join(t for t in texts if t)
+    if result.get("isError"):
+        raise RuntimeError(f"security_scan 返回错误: {body[:500]}")
+
+    findings = []
+    m = re.search(r"scanDir:\s*`([^`]+)`", body)
+    if m:
+        findings_file = Path(m.group(1)) / "findings.json"
+        try:
+            with open(findings_file) as f:
+                findings = json.load(f).get("findings", [])
+        except Exception as e:
+            log(f"⚠ findings.json 读取失败 ({e}), 仅用摘要文本")
+    else:
+        log("⚠ mimosa 摘要中未解析到 scanDir, 仅用摘要文本")
+    return body, findings
+
+
+def _compact_findings(findings):
+    """findings 投影到复核所需字段 (控制附件体积; 同类多 occurrence 逐条保留)。"""
+    out = []
+    for f in findings:
+        loc = f.get("location") or {}
+        out.append({
+            "severity": f.get("severity"),
+            "class": (f.get("identity") or {}).get("publicClass"),
+            "cwe": f.get("cwe"),
+            "path": loc.get("path"),
+            "line": loc.get("line"),
+            "title": f.get("title"),
+            "message": f.get("message"),
+        })
+    return out
+
+
+# ============================================================
 # Tool 定义
 # ============================================================
 TOOLS = [
@@ -267,9 +432,10 @@ TOOLS = [
     {
         "name": "zcode_review",
         "description": (
-            "调用 headless ZCode (GLM-5.2) 审查代码,返回审查结论。"
-            "内部以只读模式 (--mode plan) 运行,不会修改任何文件,安全。"
-            "适用于: 安全审查、代码质量评审、找 bug、最佳实践建议。"
+            "调用 headless ZCode (GLM) 审查代码,返回审查结论。"
+            "以 yolo+写/执行工具物理禁用运行: 全程免人工授权,可自由阅读代码但改不了任何文件,安全。"
+            "适用于: 代码质量评审、找 bug、最佳实践建议。"
+            "安全专项审查建议用 zcode_security_review (带 mimosa 规则引擎预扫)。"
             "可审查单个文件、多个文件,或直接传入代码文本。"
         ),
         "inputSchema": {
@@ -297,6 +463,34 @@ TOOLS = [
             "additionalProperties": False,
         },
     },
+    {
+        "name": "zcode_security_review",
+        "description": (
+            "安全专项审查,两阶段: ① mimosa 确定性规则引擎全仓快扫 (零 LLM 流量,"
+            "覆盖面兜底) → ② headless ZCode 拿着 findings 逐条核实 (确认真漏洞/"
+            "排除误报/给出攻击路径与修复建议),并可发现清单之外的问题。"
+            "zcode 同样以 yolo+写工具物理禁用运行,只输出报告不动代码。"
+            "需要本机装有 mimosa 插件 (或设 ZCODE_BRIDGE_MIMOSA_ROOT 指向插件根)。"
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "要扫描审查的项目目录,默认当前目录",
+                },
+                "focus": {
+                    "type": "string",
+                    "description": "可选,额外审查重点,如 '重点关注注入与鉴权'",
+                },
+                "cwd": {
+                    "type": "string",
+                    "description": "zcode 工作目录,默认与 path 相同",
+                },
+            },
+            "additionalProperties": False,
+        },
+    },
 ]
 
 
@@ -317,45 +511,33 @@ def tool_get_zcode_capabilities(args):
     return {"content": [{"type": "text", "text": result.stdout}]}
 
 
-def tool_zcode_review(args):
-    files = args.get("files", [])
-    code = args.get("code")
-    focus = args.get("focus", "全面审查: 安全、正确性、可维护性")
-    cwd = args.get("cwd")
+def _extract_response(output):
+    """--json 模式下 zcode stdout 是 JSON, 提取 response 字段; 解析失败原样返回。"""
+    try:
+        data = json.loads((output or "").strip())
+        if isinstance(data, dict) and isinstance(data.get("response"), str):
+            return data["response"]
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return output
 
-    # 构造 prompt
-    prompt = (
-        f"你是资深代码审查专家。请审查以下代码,重点: {focus}。\n"
-        f"输出格式: 按严重程度 (严重/警告/建议) 分级,每个问题含文件位置和修复建议。用中文。"
-    )
 
-    # 构造 zcode 命令
-    cmd = [ZCODE_BIN, "--prompt", prompt, "--mode", "plan", "--no-color"]
+def _build_review_cmd(prompt, cwd):
+    """构造只读 review 的 zcode 命令 (yolo 免授权 + 写/执行工具物理禁用 + JSON 输出)。"""
+    cmd = [ZCODE_BIN, "--prompt", prompt,
+           "--mode", "yolo",
+           "--disallowed-tools", REVIEW_DISALLOWED_TOOLS,
+           "--no-color", "--json"]
     if cwd:
         cmd += ["--cwd", cwd]
+    return cmd
 
-    # 处理文件附件 + 内联代码
-    attach_files = list(files)
-    tmp_path = None  # 记录本次创建的临时文件 (修复 P2.5: 不用 glob 误删并发请求的文件)
-    if code:
-        import tempfile
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".txt", delete=False, prefix="zcode-review-"
-        )
-        tmp.write(code)
-        tmp.close()
-        tmp_path = tmp.name
-        attach_files.append(tmp_path)
 
-    for f in attach_files:
-        cmd += ["--attach", f]
+def _run_zcode_headless(cmd, env, timeout):
+    """带文件锁 + 限流有限重试执行 zcode headless, 返回 MCP result dict。
 
-    log(f"调用 zcode review: {len(attach_files)} 个输入")
-
-    # 注入凭证: MCP server 子进程不继承 shell 环境变量, 需自行读取。
-    # 显式非空环境变量优先 (issue #3 子项2): 已设置非空的会覆盖 config; 空串视为未设置。
-    env = _merge_env_with_creds(load_zcode_credentials())
-
+    锁与重试语义见 ReviewFileLock / _parse_provider_error 注释 (issue #3)。
+    """
     # 有限重试配置 (issue #3 子项3c): 仅对 provider 限流错误重试, 退避指数。
     # clamp 到 >=0, 防止 ZCODE_BRIDGE_MAX_RETRIES=-1 导致不执行 zcode (Codex P2)
     max_retries = max(0, _env_int("ZCODE_BRIDGE_MAX_RETRIES", 3))
@@ -367,7 +549,7 @@ def tool_zcode_review(args):
             for attempt in range(max_retries + 1):
                 try:
                     result = subprocess.run(
-                        cmd, capture_output=True, text=True, timeout=120, env=env
+                        cmd, capture_output=True, text=True, timeout=timeout, env=env
                     )
                     output = result.stdout
                     # 错误判定: 只解析 stderr (Claude review P1-1: 若把 stdout 审查正文
@@ -393,11 +575,11 @@ def tool_zcode_review(args):
                         return {"content": [{"type": "text",
                                              "text": f"zcode 调用失败{suffix}: {err_text[:500]}"}],
                                 "isError": True}
-                    # 成功 (也可能 stdout 空但无错误 → 正常返回空)
-                    return {"content": [{"type": "text", "text": output}]}
+                    # 成功 (--json 输出提取 response; 非 JSON 原样返回)
+                    return {"content": [{"type": "text", "text": _extract_response(output)}]}
 
                 except subprocess.TimeoutExpired:
-                    return {"content": [{"type": "text", "text": "zcode review 超时 (120s)"}],
+                    return {"content": [{"type": "text", "text": f"zcode review 超时 ({timeout}s)"}],
                             "isError": True}
             # 理论不可达 (循环内都 return), 兜底
             return {"content": [{"type": "text", "text": f"zcode 调用失败: 重试耗尽 {last_err}"}],
@@ -405,8 +587,133 @@ def tool_zcode_review(args):
     except TimeoutError as e:
         return {"content": [{"type": "text", "text": f"zcode review 获取锁超时: {e}"}],
                 "isError": True}
+
+
+def _review_timeout():
+    """review 单次 zcode 调用超时 (秒), ZCODE_BRIDGE_REVIEW_TIMEOUT 可配。"""
+    return max(30, _env_int("ZCODE_BRIDGE_REVIEW_TIMEOUT", 300))
+
+
+def _write_temp(text, prefix):
+    """写临时文件并返回路径 (调用方负责清理)。"""
+    import tempfile
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, prefix=prefix)
+    tmp.write(text)
+    tmp.close()
+    return tmp.name
+
+
+def tool_zcode_review(args):
+    files = args.get("files", [])
+    code = args.get("code")
+    focus = args.get("focus", "全面审查: 安全、正确性、可维护性")
+    cwd = args.get("cwd")
+
+    # 构造 prompt — "只审不修"职责钉死在文本层, 写工具在工具集层物理禁用,
+    # 双保险防 "审着审着顺手改了" (plan→build 惯性, 2026-08-08 重构动因)。
+    prompt = (
+        f"你是资深代码审查专家。请审查附件中的代码,重点: {focus}。\n"
+        "规则:\n"
+        "1. 你的任务只是审查并输出报告 — 绝对不要修改、创建或删除任何文件"
+        " (写/执行工具已被物理禁用,不要尝试)。\n"
+        "2. 可以用只读工具 (Read/Grep/Glob) 阅读项目中的相关代码,获取更多上下文。\n"
+        "3. 不要提出\"我可以帮你修复\"之类的提议 — 是否修复、谁来修复由调用方决定。\n"
+        "输出格式: 按严重程度 (严重/警告/建议) 分级,每个问题含文件位置和修复建议。用中文。"
+    )
+
+    cmd = _build_review_cmd(prompt, cwd)
+
+    # 处理文件附件 + 内联代码
+    attach_files = list(files)
+    tmp_path = None  # 记录本次创建的临时文件 (修复 P2.5: 不用 glob 误删并发请求的文件)
+    if code:
+        tmp_path = _write_temp(code, "zcode-review-")
+        attach_files.append(tmp_path)
+
+    for f in attach_files:
+        cmd += ["--attach", f]
+
+    log(f"调用 zcode review: {len(attach_files)} 个输入 (yolo+只读黑名单)")
+
+    # 注入凭证: MCP server 子进程不继承 shell 环境变量, 需自行读取。
+    # 显式非空环境变量优先 (issue #3 子项2): 已设置非空的会覆盖 config; 空串视为未设置。
+    env = _merge_env_with_creds(load_zcode_credentials())
+
+    try:
+        return _run_zcode_headless(cmd, env, _review_timeout())
     finally:
         # 只清理本次创建的临时文件 (不用 glob, 避免误删并发请求的文件)
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def tool_zcode_security_review(args):
+    """mimosa 规则引擎预扫 + zcode 只读复核 的安全专项管线。
+
+    ① mimosa security_scan (确定性规则, 零 LLM 流量) 全仓快扫 → findings 清单,
+      解决"AI 自由探索覆盖面随缘"的问题;
+    ② findings 作附件喂给 zcode, 逐条核实 (确认/误报/存疑 + 攻击路径 + 修复建议),
+      读工具全开可查证上下文, 写工具物理禁用保证只审不修。
+    """
+    scan_path = args.get("path") or args.get("cwd") or os.getcwd()
+    focus = args.get("focus", "")
+    cwd = args.get("cwd") or scan_path
+
+    root = _find_mimosa_root()
+    if not root:
+        return {"content": [{"type": "text", "text": (
+            "未找到 mimosa 安全扫描插件。请安装 mimosa,或设 ZCODE_BRIDGE_MIMOSA_ROOT "
+            "指向插件根目录 (含 payload/ 的那层);也可改用 zcode_review 做纯 AI 审查。"
+        )}], "isError": True}
+
+    # ① mimosa 快扫 (不走 review 文件锁: 确定性引擎无 LLM 限流问题)
+    log(f"mimosa 快扫: {scan_path} (root={root})")
+    try:
+        summary_text, findings = _mimosa_quick_scan(root, scan_path)
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"mimosa 扫描失败: {e}"}],
+                "isError": True}
+
+    # 附件 = 扫描摘要 + 结构化 findings (投影到复核所需字段)
+    attachment = f"# mimosa 扫描摘要\n{summary_text}\n"
+    if findings:
+        compact = _compact_findings(findings)
+        attachment += (
+            f"\n# findings 清单 ({len(compact)} 条, 逐条核实)\n"
+            + json.dumps(compact, ensure_ascii=False, indent=1)
+        )
+    else:
+        attachment += "\n# findings 清单\n(未取到结构化 findings, 以摘要为准;"
+        attachment += "如摘要显示 0 发现, 也请按你的判断抽查关键代码)\n"
+
+    # ② findings 落临时文件 → 附件喂 zcode 复核
+    tmp_path = None
+    try:
+        tmp_path = _write_temp(attachment, "zcode-mimosa-findings-")
+        prompt = (
+            "你是资深安全审查专家。附件是安全扫描器 (mimosa,确定性规则引擎) 对本项目的扫描结果。\n"
+            "任务:\n"
+            "1. 逐条核实每个 finding: 用只读工具 (Read/Grep/Glob) 阅读相关代码,判定为"
+            "【确认漏洞】/【误报】/【存疑】,给出依据 (可利用的攻击路径,或为什么不可利用)。\n"
+            "2. 对每个确认漏洞给出修复建议 (只写建议,不要动手修)。\n"
+            "3. 阅读过程中如发现清单之外的安全问题,一并报告。\n"
+            "规则: 绝对不要修改、创建或删除任何文件 (写/执行工具已被物理禁用);"
+            "不要提出\"帮你修复\"的提议;只输出审查报告。\n"
+            "输出格式: 先给汇总 (确认/误报/存疑各几条),再逐条详述 (位置/判定/依据/修复建议)。用中文。"
+        )
+        if focus:
+            prompt += f"\n额外审查重点: {focus}。"
+
+        cmd = _build_review_cmd(prompt, cwd)
+        cmd += ["--attach", tmp_path]
+
+        log("调用 zcode 复核 mimosa findings (yolo+只读黑名单)")
+        env = _merge_env_with_creds(load_zcode_credentials())
+        return _run_zcode_headless(cmd, env, _review_timeout())
+    finally:
         if tmp_path:
             try:
                 os.unlink(tmp_path)
@@ -425,6 +732,7 @@ def _env_int(name, default):
 TOOL_HANDLERS = {
     "get_zcode_capabilities": tool_get_zcode_capabilities,
     "zcode_review": tool_zcode_review,
+    "zcode_security_review": tool_zcode_security_review,
 }
 
 

--- a/packages/mcp-server/zcode-mcp-server
+++ b/packages/mcp-server/zcode-mcp-server
@@ -273,7 +273,8 @@ def _find_mimosa_root():
     home = Path.home()
     for pat in (".local/share/mimosa/*",
                 ".zcode/cli/plugins/cache/*/mimosa/*"):
-        # 按版本号数值排序 (非字符串序, 防 1.10.0 < 1.9.0 误判; 狗食 review P2-1)
+        # 按版本号数值排序 (非字符串序, 防 1.10.0 < 1.9.0 误判; 狗食 review P2-1。
+        # 仅支持纯数字语义版本; 预发布版 (1.0.3-beta) 等非数字段按 0 处理)
         candidates.extend(
             str(p) for p in sorted(
                 home.glob(pat), reverse=True,
@@ -396,8 +397,14 @@ def _mimosa_quick_scan(root, scan_path):
             scan_dir = Path(m.group(1)).resolve()
             resolved_root = scan_root.resolve()
             if scan_dir == resolved_root or resolved_root in scan_dir.parents:
-                with open(scan_dir / "findings.json") as f:
-                    findings = json.load(f).get("findings", [])
+                # 复审 P1-A: findings.json 本身 resolve 后也须在根下,
+                # 防"目录合法但 findings.json 是指向外部的 symlink"绕过
+                real_file = (scan_dir / "findings.json").resolve()
+                if resolved_root in real_file.parents or real_file.parent == resolved_root:
+                    with open(real_file) as f:
+                        findings = json.load(f).get("findings", [])
+                else:
+                    log(f"⚠ findings.json 解析后越界 (疑似 symlink), 跳过回读: {real_file}")
             else:
                 log(f"⚠ scanDir 越界 (不在 {resolved_root} 下), 跳过回读: {m.group(1)}")
         except Exception as e:

--- a/packages/mcp-server/zcode-mcp-server
+++ b/packages/mcp-server/zcode-mcp-server
@@ -266,14 +266,19 @@ def _find_mimosa_root():
     """定位 mimosa 插件根目录 (含 payload/dist/mcp/server.js 的那层)。
 
     ZCODE_BRIDGE_MIMOSA_ROOT 优先; 否则探测常见安装位 (独立副本 + zcode
-    插件缓存), 同目录多版本取路径排序最大者。找不到返回 None。
+    插件缓存), 同目录多版本取版本号最大者。找不到返回 None。
     """
     env_root = os.environ.get("ZCODE_BRIDGE_MIMOSA_ROOT")
     candidates = [env_root] if env_root else []
     home = Path.home()
     for pat in (".local/share/mimosa/*",
                 ".zcode/cli/plugins/cache/*/mimosa/*"):
-        candidates.extend(str(p) for p in sorted(home.glob(pat), reverse=True))
+        # 按版本号数值排序 (非字符串序, 防 1.10.0 < 1.9.0 误判; 狗食 review P2-1)
+        candidates.extend(
+            str(p) for p in sorted(
+                home.glob(pat), reverse=True,
+                key=lambda p: [int(x) if x.isdigit() else 0
+                               for x in p.name.split(".")]))
     for c in candidates:
         if c and (Path(c) / "payload" / "dist" / "mcp" / "server.js").exists():
             return c
@@ -314,7 +319,13 @@ class MimosaMcpClient:
         line = self._proc.stdout.readline()
         if not line:
             raise RuntimeError("mimosa MCP server 提前退出 (stdout EOF)")
-        return json.loads(line)
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError as e:
+            # 狗食 review P1-2: 裸 JSONDecodeError 冒泡会被调用方笼统包成
+            # "扫描失败", 吞掉"子进程输出损坏"这个真根因 → 转成带上下文的错误
+            raise RuntimeError(
+                f"mimosa MCP 返回非 JSON 行 (前80字符): {line[:80]!r}") from e
 
     def _request(self, method, params):
         self._id += 1
@@ -375,10 +386,20 @@ def _mimosa_quick_scan(root, scan_path):
     findings = []
     m = re.search(r"scanDir:\s*`([^`]+)`", body)
     if m:
-        findings_file = Path(m.group(1)) / "findings.json"
+        # 狗食 review P1-1: scanDir 是不可信输入 (子进程产物经文本协议传回,
+        # 属信任边界外) — 必须校验落在 mimosa 扫描历史根之下, 防路径注入
+        # 导致任意文件回读喂给 LLM。校验失败降级为仅用摘要文本。
+        scan_root = Path(os.environ.get(
+            "ZCODE_BRIDGE_MIMOSA_SCAN_ROOT",
+            str(Path.home() / ".mimosa" / "security-scans")))
         try:
-            with open(findings_file) as f:
-                findings = json.load(f).get("findings", [])
+            scan_dir = Path(m.group(1)).resolve()
+            resolved_root = scan_root.resolve()
+            if scan_dir == resolved_root or resolved_root in scan_dir.parents:
+                with open(scan_dir / "findings.json") as f:
+                    findings = json.load(f).get("findings", [])
+            else:
+                log(f"⚠ scanDir 越界 (不在 {resolved_root} 下), 跳过回读: {m.group(1)}")
         except Exception as e:
             log(f"⚠ findings.json 读取失败 ({e}), 仅用摘要文本")
     else:
@@ -595,7 +616,11 @@ def _review_timeout():
 
 
 def _write_temp(text, prefix):
-    """写临时文件并返回路径 (调用方负责清理)。"""
+    """写临时文件并返回路径 (调用方负责清理)。
+
+    内容是调用方自己的代码/scan findings (非凭证); POSIX 下 tempfile
+    默认 0600 仅属主可读, 权限足够 (狗食安全 review 存疑-1 已评估)。
+    """
     import tempfile
     tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, prefix=prefix)
     tmp.write(text)
@@ -661,6 +686,11 @@ def tool_zcode_security_review(args):
     scan_path = args.get("path") or args.get("cwd") or os.getcwd()
     focus = args.get("focus", "")
     cwd = args.get("cwd") or scan_path
+
+    if not os.path.isdir(scan_path):  # 狗食 review P2-8: 先校验, 错误信息明确
+        return {"content": [{"type": "text",
+                             "text": f"扫描目录不存在或不是目录: {scan_path}"}],
+                "isError": True}
 
     root = _find_mimosa_root()
     if not root:

--- a/skills/zcode-bridge-guide/SKILL.md
+++ b/skills/zcode-bridge-guide/SKILL.md
@@ -86,7 +86,8 @@ for k,v in c['provider'].items():
 ```bash
 zcode --prompt "<prompt>" --attach <file> --mode build --json
 # --mode build   允许写文件 + 执行命令
-# --mode plan    只读分析，不改文件（最安全，适合审查）
+# --mode plan    只读分析，不改文件（注意: 只禁写, 不禁止读探索/子代理;
+#                自动化审查推荐用下方"评审形态"的 yolo+黑名单组合）
 # --mode edit    允许写文件，不执行命令
 # --mode yolo    全自动（--prompt 的默认模式）
 # --json         输出 JSON（含 sessionId, response, usage）
@@ -109,7 +110,15 @@ zcode --target "新目标" --target-replace
 
 ### 评审形态（只读）
 ```bash
-zcode --prompt "<review-prompt>" --attach <file> --mode plan --json
+# MCP server 的 zcode_review 内部用的形态（推荐，物理只读）：
+zcode --prompt "<review-prompt>" --attach <file> --mode yolo \
+  --disallowed-tools "Write Edit MultiEdit ApplyPatch Bash js js_reset js_add_node_module_dir mcp__node_repl__js mcp__node_repl__js_reset mcp__node_repl__js_add_node_module_dir" \
+  --no-color --json
+# 原理: --mode yolo 全程免授权; --disallowed-tools 是工具集级物理移除 (先于权限层,
+# yolo 也绕不过), 写/执行工具连同 Node REPL 一族一起禁 = 改不了任何文件。
+# 注意: js / mcp__node_repl__js* 必须同禁, 否则可被 execSync 打穿 Bash 黑名单 (0.16.1 实测)。
+# 旧形态 --mode plan 已不推荐: plan 只禁"改文件", 读探索/子代理照样放行 (限流超时主因),
+# 且 plan→build 惯性容易让 review 变成"边审边修"。
 ```
 
 ### 显式 env 包装（非交互 shell 用）
@@ -135,7 +144,7 @@ ANTHROPIC_API_KEY="$api_key" ZCODE_BASE_URL="$base_url" ZCODE_MODEL="$model" \
 1. **不支持 stdin 管道**：不能 `cat file | zcode --prompt`，必须用 `--attach`
 2. **无流式输出**（`--stream-json` 不支持）：turn 结束一次性返回
 3. **tool call 轮次不稳定**：duration 38s~100s+，有时不完成
-4. **自由 prompt 可能触发限流**：开放式 prompt 会 spawn 多个 explore 子代理，撞 z.ai 限流。修法：把证据塞进 `--attach`，prompt 写明「不要调用工具/不要 spawn 子代理，只基于附件推理」
+4. **自由 prompt 可能触发限流**：开放式 prompt 会 spawn 多个 explore 子代理，撞 z.ai 限流。修法：把证据塞进 `--attach`，prompt 写明「不要调用工具/不要 spawn 子代理，只基于附件推理」。MCP server 的 `zcode_review` / `zcode_security_review` 两个 tool 已内置此纪律（prompt 内置「只审不修」约束 + 写/执行工具物理禁用 + 证据走附件），走 MCP 调用时无需手工处理
 
 ---
 
@@ -294,7 +303,7 @@ ACP bridge 暴露的 ZCode 新版协议方法，按定位维度分组。**sessio
 
 ## 模式三：MCP tools（MCP client 内直接调用）
 
-MCP server 暴露两个标准 MCP tool，供 Claude Code / Cursor 等 MCP client 调用。
+MCP server 暴露三个标准 MCP tool，供 Claude Code / Cursor 等 MCP client 调用。
 
 ### 注册到 MCP client
 
@@ -318,13 +327,21 @@ MCP server 暴露两个标准 MCP tool，供 Claude Code / Cursor 等 MCP client
 | Tool | 用途 | 安全性 |
 |------|------|--------|
 | `get_zcode_capabilities` | 返回 ZCode 完整能力清单 | 只读 |
-| `zcode_review` | 调用 ZCode 审查代码 | 只读（`--mode plan`，不改文件） |
+| `zcode_review` | 调用 ZCode 审查代码 | 只读（`--mode yolo` + `--disallowed-tools` 物理禁用写/执行工具，全程免授权但改不了文件） |
+| `zcode_security_review` | 安全专项审查：mimosa 规则引擎全仓预扫 → ZCode 逐条核实 findings | 只读（同上；需本机装有 mimosa 或设 `ZCODE_BRIDGE_MIMOSA_ROOT`） |
 
 ### `zcode_review` 参数
 - `files`：要审查的文件路径列表
 - `code`：直接传入代码文本（与 files 二选一或组合）
 - `focus`：审查重点（如 "安全性"、"性能"、"找 bug"）
 - `cwd`：工作目录（影响 zcode 的项目上下文）
+
+### `zcode_security_review` 参数
+- `path`：要扫描审查的项目目录（默认当前目录）
+- `focus`：可选，额外审查重点（如 "重点关注注入与鉴权"）
+- `cwd`：zcode 工作目录（默认与 path 相同）
+
+> 两阶段流程：① mimosa `security_scan`（确定性规则引擎，零 LLM 流量）全仓快扫出 findings；② findings 作 `--attach` 附件喂 zcode 逐条核实（确认漏洞/误报/存疑 + 攻击路径 + 修复建议），并可发现清单之外的问题。mimosa 定位：`ZCODE_BRIDGE_MIMOSA_ROOT` 优先，否则探测 `~/.local/share/mimosa/*` 与 `~/.zcode/cli/plugins/cache/*/mimosa/*`；扫描超时 `ZCODE_BRIDGE_MIMOSA_TIMEOUT`（默认 180s）。
 
 ---
 
@@ -413,7 +430,7 @@ npm test     # 全量，看实际数字
 - 流式事件中的 `agent_message_chunk` → 文本输出（真流式有多段）
 
 ### MCP 模式
-- `zcode_review` 返回 `{content: [{type: "text", text: "..."}]}`
+- `zcode_review` / `zcode_security_review` 返回 `{content: [{type: "text", text: "..."}]}`；text 是 zcode `--json` 输出中提取的 `response` 字段（输出非 JSON 时原样返回）
 - `isError: true` → 失败
 
 ---

--- a/tests/test_security_review.py
+++ b/tests/test_security_review.py
@@ -344,6 +344,27 @@ class TestMimosaQuickScan(_EnvGuard):
         body, findings = self._run_scan(EvilClient)
         self.assertEqual(findings, [], "越界 scanDir 不应回读任何 findings")
 
+    def test_ms2c_symlink_findings_rejected(self):
+        """MS2c: scanDir 合法但 findings.json 是指向根外的 symlink → 拒绝 (复审 P1-A/B)"""
+        import tempfile
+        scan_root = tempfile.mkdtemp(prefix="mimosa-scans-")
+        outside = tempfile.mkdtemp(prefix="mimosa-outside-")
+        for d in (scan_root, outside):
+            self.addCleanup(lambda d=d: __import__("shutil").rmtree(d, ignore_errors=True))
+        secret = os.path.join(outside, "secret.json")
+        with open(secret, "w") as f:
+            json.dump({"findings": [{"severity": "high", "title": "不该被读到"}]}, f)
+        scan_dir = os.path.join(scan_root, "project-x", "scan-1")
+        os.makedirs(scan_dir)
+        os.symlink(secret, os.path.join(scan_dir, "findings.json"))
+        os.environ["ZCODE_BRIDGE_MIMOSA_SCAN_ROOT"] = scan_root
+
+        class SymlinkClient(_StubMimosaClient):
+            response_text = f"**Mimosa**\n- scanDir: `{scan_dir}`\n- findings: 1"
+
+        body, findings = self._run_scan(SymlinkClient)
+        self.assertEqual(findings, [], "symlink 指向根外的 findings.json 不应被读")
+
     def test_ms3_compact_projection(self):
         """MS3: _compact_findings 投影保留复核所需字段"""
         findings = [{
@@ -426,7 +447,7 @@ class TestSecurityReviewTool(_EnvGuard):
 
         mod.subprocess.run = fake_run
         try:
-            result = mod.tool_zcode_security_review({"path": "/tmp"})
+            result = mod.tool_zcode_security_review({"path": proj})
         finally:
             self._restore_common(mod, saved)
         self.assertTrue(result.get("isError"))

--- a/tests/test_security_review.py
+++ b/tests/test_security_review.py
@@ -1,0 +1,457 @@
+"""
+test_security_review.py — review 只读护栏 + zcode_security_review 管线单测
+
+覆盖 2026-08-08 重构 (告别 --mode plan):
+  - _build_review_cmd: yolo + 写/执行工具全黑名单 + --json, 不含 plan
+  - review prompt 含"只审不修"约束
+  - _extract_response: --json 输出提取 response / 非 JSON 原样返回
+  - _find_mimosa_root: env 覆盖 / 找不到返回 None
+  - MimosaMcpClient: stdio JSON-RPC 握手 + tools/call (假 server 实测)
+  - _mimosa_quick_scan: content 提取 / isError 抛异常
+  - tool_zcode_security_review: mimosa 缺失报错 / 扫描失败报错 / 正常管线
+
+运行: python3 tests/test_security_review.py
+依赖: 仅 Python 标准库 + zcode-mcp-server 模块
+"""
+
+import json
+import os
+import subprocess
+import sys
+import types
+import unittest
+
+MCP_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "packages", "mcp-server", "zcode-mcp-server"
+)
+
+
+def _load_mcp_module():
+    mod = types.ModuleType("zcode_mcp_server")
+    mod.__file__ = MCP_PATH
+    with open(MCP_PATH) as f:
+        code = f.read()
+    code_no_main = code.split('if __name__ == "__main__":')[0]
+    exec(code_no_main, mod.__dict__)
+    return mod
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# 假 mimosa MCP server (stdio JSON-RPC): initialize 回握手, tools/call 回固定文本
+_FAKE_SERVER = r"""
+import json, sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    method = req.get("method")
+    if method == "initialize":
+        resp = {"jsonrpc": "2.0", "id": req["id"],
+                "result": {"protocolVersion": "2024-11-05", "capabilities": {},
+                           "serverInfo": {"name": "fake-mimosa", "version": "0"}}}
+        sys.stdout.write(json.dumps(resp) + "\n"); sys.stdout.flush()
+    elif method == "tools/call":
+        resp = {"jsonrpc": "2.0", "id": req["id"],
+                "result": {"content": [{"type": "text", "text": "FINDINGS-OK"}]}}
+        sys.stdout.write(json.dumps(resp) + "\n"); sys.stdout.flush()
+    # notification (notifications/initialized): 无响应
+"""
+
+
+class _EnvGuard(unittest.TestCase):
+    """保存/恢复本文件用到的环境变量。"""
+
+    ENV_KEYS = ("ZCODE_BRIDGE_REVIEW_LOCK", "ZCODE_BRIDGE_MIMOSA_ROOT",
+                "ZCODE_BRIDGE_REVIEW_TIMEOUT")
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in self.ENV_KEYS}
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class TestReviewCmd(_EnvGuard):
+    """只读护栏: 命令构造 + prompt 约束"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_mcp_module()
+
+    def _capture_cmd(self, **kwargs):
+        """patch subprocess.run 捕获 cmd, 返回 (cmd, result)。"""
+        mod = self.mod
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return _FakeCompletedProcess(returncode=0, stdout="OK", stderr="")
+
+        saved = mod.subprocess.run
+        mod.subprocess.run = fake_run
+        os.environ["ZCODE_BRIDGE_REVIEW_LOCK"] = "0"
+        try:
+            result = mod.tool_zcode_review({"code": "print('x')", **kwargs})
+        finally:
+            mod.subprocess.run = saved
+        return captured["cmd"], result
+
+    def test_rc0_yolo_not_plan(self):
+        """RC0: 用 --mode yolo, 绝不再出现 plan"""
+        cmd, _ = self._capture_cmd()
+        self.assertIn("--mode", cmd)
+        self.assertEqual(cmd[cmd.index("--mode") + 1], "yolo")
+        self.assertNotIn("plan", cmd)
+
+    def test_rc1_denylist_blocks_write_and_repl(self):
+        """RC1: 黑名单含写工具 + Bash + Node REPL 一族 (防 execSync 打穿)"""
+        cmd, _ = self._capture_cmd()
+        self.assertIn("--disallowed-tools", cmd)
+        deny = cmd[cmd.index("--disallowed-tools") + 1]
+        for tool in ("Write", "Edit", "ApplyPatch", "Bash",
+                     "js", "mcp__node_repl__js"):
+            self.assertIn(tool, deny.split(), f"黑名单缺 {tool}")
+
+    def test_rc2_json_output(self):
+        """RC2: 带 --json (结构化输出)"""
+        cmd, _ = self._capture_cmd()
+        self.assertIn("--json", cmd)
+
+    def test_rc3_prompt_pins_review_only(self):
+        """RC3: prompt 钉死"只审不修"职责"""
+        cmd, _ = self._capture_cmd()
+        prompt = cmd[cmd.index("--prompt") + 1]
+        self.assertIn("绝对不要修改", prompt)
+        self.assertIn("只读工具", prompt)
+
+    def test_rc4_timeout_env_configurable(self):
+        """RC4: 单次超时由 ZCODE_BRIDGE_REVIEW_TIMEOUT 控制 (默认 300)"""
+        mod = self.mod
+        self.assertEqual(mod._review_timeout(), 300)
+        os.environ["ZCODE_BRIDGE_REVIEW_TIMEOUT"] = "60"
+        self.assertEqual(mod._review_timeout(), 60)
+        os.environ["ZCODE_BRIDGE_REVIEW_TIMEOUT"] = "1"  # clamp 下限 30
+        self.assertEqual(mod._review_timeout(), 30)
+
+
+class TestExtractResponse(unittest.TestCase):
+    """--json 输出的 response 提取"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_mcp_module()
+
+    def test_ex0_json_response_extracted(self):
+        out = json.dumps({"response": "审查结论正文", "usage": {}}, ensure_ascii=False)
+        self.assertEqual(self.mod._extract_response(out), "审查结论正文")
+
+    def test_ex1_non_json_passthrough(self):
+        self.assertEqual(self.mod._extract_response("纯文本结论"), "纯文本结论")
+
+    def test_ex2_json_without_response_passthrough(self):
+        raw = json.dumps({"error": "something"})
+        self.assertEqual(self.mod._extract_response(raw), raw)
+
+    def test_ex3_end_to_end_via_tool(self):
+        """tool_zcode_review 成功路径返回的是提取后的 response, 不是整个 JSON"""
+        mod = self.mod
+        payload = json.dumps({"response": "提取后的正文"}, ensure_ascii=False)
+        saved = mod.subprocess.run
+        mod.subprocess.run = lambda *a, **kw: _FakeCompletedProcess(0, payload, "")
+        os.environ["ZCODE_BRIDGE_REVIEW_LOCK"] = "0"
+        try:
+            result = mod.tool_zcode_review({"code": "x"})
+        finally:
+            mod.subprocess.run = saved
+            os.environ.pop("ZCODE_BRIDGE_REVIEW_LOCK", None)
+        self.assertNotIn("isError", result)
+        self.assertEqual(result["content"][0]["text"], "提取后的正文")
+
+
+class TestFindMimosaRoot(_EnvGuard):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_mcp_module()
+
+    def test_fm0_env_override(self):
+        """FM0: ZCODE_BRIDGE_MIMOSA_ROOT 指向合法根 → 采用"""
+        import tempfile
+        d = tempfile.mkdtemp(prefix="mimosa-root-")
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        os.makedirs(os.path.join(d, "payload", "dist", "mcp"))
+        open(os.path.join(d, "payload", "dist", "mcp", "server.js"), "w").close()
+        os.environ["ZCODE_BRIDGE_MIMOSA_ROOT"] = d
+        self.assertEqual(self.mod._find_mimosa_root(), d)
+
+    def test_fm1_env_invalid_returns_none_or_fallback(self):
+        """FM1: env 指向无效目录 → 不被采用 (落回探测或 None)"""
+        os.environ["ZCODE_BRIDGE_MIMOSA_ROOT"] = "/nonexistent/mimosa"
+        root = self.mod._find_mimosa_root()
+        self.assertNotEqual(root, "/nonexistent/mimosa")
+        if root is not None:  # 本机若真装了 mimosa 则必须合法
+            self.assertTrue(os.path.exists(
+                os.path.join(root, "payload", "dist", "mcp", "server.js")))
+
+
+class TestMimosaMcpClient(_EnvGuard):
+    """MimosaMcpClient 协议层 (假 stdio server 实测握手 + tools/call)"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_mcp_module()
+        import tempfile
+        cls._fake = os.path.join(
+            tempfile.mkdtemp(prefix="fake-mcp-"), "fake_server.py")
+        with open(cls._fake, "w") as f:
+            f.write(_FAKE_SERVER)
+
+    def _make_client(self):
+        """绕过 __init__ (不起 node), 直接挂上假 server 子进程。"""
+        client = object.__new__(self.mod.MimosaMcpClient)
+        client._proc = subprocess.Popen(
+            [sys.executable, self._fake],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+        client.timeout = 10
+        client._id = 0
+        return client
+
+    def test_mc0_handshake_and_call(self):
+        """MC0: initialize + tools/call 全流程"""
+        client = self._make_client()
+        try:
+            client.initialize()  # 不抛异常即握手成功
+            result = client.call_tool("security_scan", {"path": "/tmp"})
+            texts = [c["text"] for c in result["content"]]
+            self.assertIn("FINDINGS-OK", texts)
+        finally:
+            client.close()
+
+    def test_mc1_close_idempotent(self):
+        """MC1: close 后可再 close (幂等, 不崩)"""
+        client = self._make_client()
+        client.close()
+        client.close()
+
+
+class _StubMimosaClient:
+    """_mimosa_quick_scan 的 stub (不起真子进程)。"""
+
+    #: 类属性, 测试可覆盖 (返回的 content 文本 / 是否 isError)
+    response_text = "**Mimosa deep security scan:**\n- findings: 1"
+    is_error = False
+
+    def __init__(self, root, cwd, timeout=120):
+        self.args_received = None
+
+    def initialize(self):
+        pass
+
+    def call_tool(self, name, arguments):
+        self.args_received = (name, arguments)
+        if self.is_error:
+            return {"isError": True,
+                    "content": [{"type": "text", "text": "engine boom"}]}
+        return {"content": [{"type": "text", "text": self.response_text}]}
+
+    def close(self):
+        pass
+
+
+class TestMimosaQuickScan(_EnvGuard):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_mcp_module()
+
+    def _run_scan(self, stub_cls=_StubMimosaClient):
+        mod = self.mod
+        saved = mod.MimosaMcpClient
+        mod.MimosaMcpClient = stub_cls
+        try:
+            return mod._mimosa_quick_scan("/fake/root", "/fake/proj")
+        finally:
+            mod.MimosaMcpClient = saved
+
+    def test_ms0_summary_returned(self):
+        """MS0: 摘要文本原样返回; 无 scanDir 时 findings 为空"""
+        body, findings = self._run_scan()
+        self.assertIn("Mimosa", body)
+        self.assertEqual(findings, [])
+
+    def test_ms1_is_error_raises(self):
+        """MS1: isError 响应 → 抛 RuntimeError"""
+        class ErrClient(_StubMimosaClient):
+            is_error = True
+        with self.assertRaises(RuntimeError) as ctx:
+            self._run_scan(ErrClient)
+        self.assertIn("engine boom", str(ctx.exception))
+
+    def test_ms2_scandir_findings_read_back(self):
+        """MS2: 摘要含 scanDir → 回读 findings.json 全量"""
+        import tempfile
+        scan_dir = tempfile.mkdtemp(prefix="mimosa-scan-")
+        self.addCleanup(lambda: __import__("shutil").rmtree(scan_dir, ignore_errors=True))
+        findings_payload = {
+            "schemaVersion": "mimosa-security-scan-findings/v1",
+            "findings": [
+                {"identity": {"publicClass": "sql-injection"},
+                 "severity": "high", "cwe": ["CWE-89"],
+                 "location": {"path": "app.py", "line": 11},
+                 "title": "SQL 注入", "message": "拼接查询"},
+            ],
+        }
+        with open(os.path.join(scan_dir, "findings.json"), "w") as f:
+            json.dump(findings_payload, f)
+
+        class ScanDirClient(_StubMimosaClient):
+            response_text = f"**Mimosa deep security scan:**\n- scanDir: `{scan_dir}`\n- findings: 1"
+
+        body, findings = self._run_scan(ScanDirClient)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["severity"], "high")
+
+    def test_ms3_compact_projection(self):
+        """MS3: _compact_findings 投影保留复核所需字段"""
+        findings = [{
+            "findingId": "finding:x", "occurrenceId": "occurrence:y",
+            "identity": {"publicClass": "hardcoded-credential", "anchor": "sha256:a"},
+            "kind": "static", "severity": "high", "cwe": ["CWE-798"],
+            "location": {"path": "a.py", "line": 4, "endLine": 4},
+            "title": "硬编码凭据", "message": "密钥写在源码",
+            "proofGaps": [],
+        }]
+        compact = self.mod._compact_findings(findings)
+        self.assertEqual(len(compact), 1)
+        c = compact[0]
+        self.assertEqual(c["class"], "hardcoded-credential")
+        self.assertEqual(c["path"], "a.py")
+        self.assertEqual(c["line"], 4)
+        self.assertNotIn("anchor", c, "哈希等内部字段应被投影掉")
+
+
+class TestSecurityReviewTool(_EnvGuard):
+    """tool_zcode_security_review 管线"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_mcp_module()
+
+    def _patch_common(self, summary="摘要: findings 1",
+                      findings=None):
+        mod = self.mod
+        if findings is None:
+            findings = [{"identity": {"publicClass": "sql-injection"},
+                         "severity": "high", "cwe": ["CWE-89"],
+                         "location": {"path": "app.py", "line": 11},
+                         "title": "SQL 注入", "message": "拼接查询"}]
+        saved = {
+            "find_root": mod._find_mimosa_root,
+            "scan": mod._mimosa_quick_scan,
+            "run": mod.subprocess.run,
+        }
+        mod._find_mimosa_root = lambda: "/fake/mimosa"
+        mod._mimosa_quick_scan = lambda root, path: (summary, findings)
+        os.environ["ZCODE_BRIDGE_REVIEW_LOCK"] = "0"
+        return mod, saved
+
+    def _restore_common(self, mod, saved):
+        mod._find_mimosa_root = saved["find_root"]
+        mod._mimosa_quick_scan = saved["scan"]
+        mod.subprocess.run = saved["run"]
+
+    def test_sr0_mimosa_missing_clean_error(self):
+        """SR0: mimosa 未安装 → 明确报错并建议 fallback (不崩)"""
+        mod = self.mod
+        saved = mod._find_mimosa_root
+        mod._find_mimosa_root = lambda: None
+        try:
+            result = mod.tool_zcode_security_review({"path": "/tmp"})
+        finally:
+            mod._find_mimosa_root = saved
+        self.assertTrue(result.get("isError"))
+        self.assertIn("mimosa", result["content"][0]["text"])
+        self.assertIn("zcode_review", result["content"][0]["text"])
+
+    def test_sr1_scan_failure_clean_error(self):
+        """SR1: mimosa 扫描失败 → 明确报错, 不再调 zcode"""
+        mod, saved = self._patch_common()
+
+        def boom(root, path):
+            raise RuntimeError("engine boom")
+
+        mod._mimosa_quick_scan = boom
+        zcode_called = {"n": 0}
+
+        def fake_run(*a, **kw):
+            zcode_called["n"] += 1
+            return _FakeCompletedProcess(0, "OK", "")
+
+        mod.subprocess.run = fake_run
+        try:
+            result = mod.tool_zcode_security_review({"path": "/tmp"})
+        finally:
+            self._restore_common(mod, saved)
+        self.assertTrue(result.get("isError"))
+        self.assertIn("mimosa 扫描失败", result["content"][0]["text"])
+        self.assertEqual(zcode_called["n"], 0, "扫描失败不应再调 zcode")
+
+    def test_sr2_happy_path_pipeline(self):
+        """SR2: 正常管线 — findings 作附件, zcode 只读复核, 返回提取的 response"""
+        mod, saved = self._patch_common()
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return _FakeCompletedProcess(
+                0, json.dumps({"response": "安全报告正文"}, ensure_ascii=False), "")
+
+        mod.subprocess.run = fake_run
+        try:
+            result = mod.tool_zcode_security_review(
+                {"path": "/tmp/proj", "focus": "注入类"})
+        finally:
+            self._restore_common(mod, saved)
+        self.assertNotIn("isError", result)
+        self.assertEqual(result["content"][0]["text"], "安全报告正文")
+        cmd = captured["cmd"]
+        # yolo + 黑名单 + --json + 恰好一个 --attach (findings 临时文件)
+        self.assertEqual(cmd[cmd.index("--mode") + 1], "yolo")
+        self.assertIn("--disallowed-tools", cmd)
+        self.assertIn("--json", cmd)
+        attach_idx = [i for i, v in enumerate(cmd) if v == "--attach"]
+        self.assertEqual(len(attach_idx), 1)
+        self.assertIn("zcode-mimosa-findings-", cmd[attach_idx[0] + 1])
+        # prompt 是安全复核口径 + 含额外重点
+        prompt = cmd[cmd.index("--prompt") + 1]
+        self.assertIn("mimosa", prompt)
+        self.assertIn("确认漏洞", prompt)
+        self.assertIn("注入类", prompt)
+        self.assertIn("绝对不要修改", prompt)
+
+    def test_sr3_findings_tmpfile_cleaned(self):
+        """SR3: findings 临时文件用后被清理"""
+        mod, saved = self._patch_common()
+        captured = {}
+        mod.subprocess.run = lambda cmd, *a, **kw: (
+            captured.update(cmd=cmd),
+            _FakeCompletedProcess(0, "OK", ""))[1]
+        try:
+            mod.tool_zcode_security_review({"path": "/tmp/proj"})
+        finally:
+            self._restore_common(mod, saved)
+        attach_path = captured["cmd"][captured["cmd"].index("--attach") + 1]
+        self.assertFalse(os.path.exists(attach_path), "临时 findings 文件应被清理")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_security_review.py
+++ b/tests/test_security_review.py
@@ -69,7 +69,7 @@ class _EnvGuard(unittest.TestCase):
     """保存/恢复本文件用到的环境变量。"""
 
     ENV_KEYS = ("ZCODE_BRIDGE_REVIEW_LOCK", "ZCODE_BRIDGE_MIMOSA_ROOT",
-                "ZCODE_BRIDGE_REVIEW_TIMEOUT")
+                "ZCODE_BRIDGE_REVIEW_TIMEOUT", "ZCODE_BRIDGE_MIMOSA_SCAN_ROOT")
 
     def setUp(self):
         self._saved = {k: os.environ.get(k) for k in self.ENV_KEYS}
@@ -119,8 +119,10 @@ class TestReviewCmd(_EnvGuard):
         cmd, _ = self._capture_cmd()
         self.assertIn("--disallowed-tools", cmd)
         deny = cmd[cmd.index("--disallowed-tools") + 1]
-        for tool in ("Write", "Edit", "ApplyPatch", "Bash",
-                     "js", "mcp__node_repl__js"):
+        for tool in ("Write", "Edit", "MultiEdit", "ApplyPatch", "Bash",
+                     "js", "js_reset", "js_add_node_module_dir",
+                     "mcp__node_repl__js", "mcp__node_repl__js_reset",
+                     "mcp__node_repl__js_add_node_module_dir"):
             self.assertIn(tool, deny.split(), f"黑名单缺 {tool}")
 
     def test_rc2_json_output(self):
@@ -299,8 +301,10 @@ class TestMimosaQuickScan(_EnvGuard):
     def test_ms2_scandir_findings_read_back(self):
         """MS2: 摘要含 scanDir → 回读 findings.json 全量"""
         import tempfile
-        scan_dir = tempfile.mkdtemp(prefix="mimosa-scan-")
-        self.addCleanup(lambda: __import__("shutil").rmtree(scan_dir, ignore_errors=True))
+        scan_root = tempfile.mkdtemp(prefix="mimosa-scans-")
+        self.addCleanup(lambda: __import__("shutil").rmtree(scan_root, ignore_errors=True))
+        scan_dir = os.path.join(scan_root, "project-x", "scan-1")
+        os.makedirs(scan_dir)
         findings_payload = {
             "schemaVersion": "mimosa-security-scan-findings/v1",
             "findings": [
@@ -312,6 +316,8 @@ class TestMimosaQuickScan(_EnvGuard):
         }
         with open(os.path.join(scan_dir, "findings.json"), "w") as f:
             json.dump(findings_payload, f)
+        # scanDir 校验要求落在扫描历史根下 (狗食 review P1-1), 用 env 指定测试根
+        os.environ["ZCODE_BRIDGE_MIMOSA_SCAN_ROOT"] = scan_root
 
         class ScanDirClient(_StubMimosaClient):
             response_text = f"**Mimosa deep security scan:**\n- scanDir: `{scan_dir}`\n- findings: 1"
@@ -319,6 +325,24 @@ class TestMimosaQuickScan(_EnvGuard):
         body, findings = self._run_scan(ScanDirClient)
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["severity"], "high")
+
+    def test_ms2b_scandir_outside_root_rejected(self):
+        """MS2b: scanDir 越界 (不在扫描历史根下) → 拒绝回读 (狗食 review P1-1)"""
+        import tempfile
+        outside = tempfile.mkdtemp(prefix="mimosa-outside-")
+        self.addCleanup(lambda: __import__("shutil").rmtree(outside, ignore_errors=True))
+        with open(os.path.join(outside, "findings.json"), "w") as f:
+            json.dump({"findings": [{"severity": "high", "title": "不该被读到"}]}, f)
+        # scan root 指向另一个空目录 → outside 不在其下
+        scan_root = tempfile.mkdtemp(prefix="mimosa-scans-")
+        self.addCleanup(lambda: __import__("shutil").rmtree(scan_root, ignore_errors=True))
+        os.environ["ZCODE_BRIDGE_MIMOSA_SCAN_ROOT"] = scan_root
+
+        class EvilClient(_StubMimosaClient):
+            response_text = f"**Mimosa**\n- scanDir: `{outside}`\n- findings: 1"
+
+        body, findings = self._run_scan(EvilClient)
+        self.assertEqual(findings, [], "越界 scanDir 不应回读任何 findings")
 
     def test_ms3_compact_projection(self):
         """MS3: _compact_findings 投影保留复核所需字段"""
@@ -348,12 +372,16 @@ class TestSecurityReviewTool(_EnvGuard):
 
     def _patch_common(self, summary="摘要: findings 1",
                       findings=None):
+        import tempfile
         mod = self.mod
         if findings is None:
             findings = [{"identity": {"publicClass": "sql-injection"},
                          "severity": "high", "cwe": ["CWE-89"],
                          "location": {"path": "app.py", "line": 11},
                          "title": "SQL 注入", "message": "拼接查询"}]
+        # 扫描目录真实存在 (P2-8 校验), 用临时目录充当被扫项目
+        proj = tempfile.mkdtemp(prefix="zcode-scan-proj-")
+        self.addCleanup(lambda: __import__("shutil").rmtree(proj, ignore_errors=True))
         saved = {
             "find_root": mod._find_mimosa_root,
             "scan": mod._mimosa_quick_scan,
@@ -362,7 +390,7 @@ class TestSecurityReviewTool(_EnvGuard):
         mod._find_mimosa_root = lambda: "/fake/mimosa"
         mod._mimosa_quick_scan = lambda root, path: (summary, findings)
         os.environ["ZCODE_BRIDGE_REVIEW_LOCK"] = "0"
-        return mod, saved
+        return mod, saved, proj
 
     def _restore_common(self, mod, saved):
         mod._find_mimosa_root = saved["find_root"]
@@ -384,7 +412,7 @@ class TestSecurityReviewTool(_EnvGuard):
 
     def test_sr1_scan_failure_clean_error(self):
         """SR1: mimosa 扫描失败 → 明确报错, 不再调 zcode"""
-        mod, saved = self._patch_common()
+        mod, saved, proj = self._patch_common()
 
         def boom(root, path):
             raise RuntimeError("engine boom")
@@ -407,7 +435,7 @@ class TestSecurityReviewTool(_EnvGuard):
 
     def test_sr2_happy_path_pipeline(self):
         """SR2: 正常管线 — findings 作附件, zcode 只读复核, 返回提取的 response"""
-        mod, saved = self._patch_common()
+        mod, saved, proj = self._patch_common()
         captured = {}
 
         def fake_run(cmd, *a, **kw):
@@ -418,7 +446,7 @@ class TestSecurityReviewTool(_EnvGuard):
         mod.subprocess.run = fake_run
         try:
             result = mod.tool_zcode_security_review(
-                {"path": "/tmp/proj", "focus": "注入类"})
+                {"path": proj, "focus": "注入类"})
         finally:
             self._restore_common(mod, saved)
         self.assertNotIn("isError", result)
@@ -438,15 +466,22 @@ class TestSecurityReviewTool(_EnvGuard):
         self.assertIn("注入类", prompt)
         self.assertIn("绝对不要修改", prompt)
 
+    def test_sr3b_scan_path_missing_clean_error(self):
+        """SR3b: 扫描目录不存在 → 明确报错 (狗食 review P2-8), 不调 mimosa/zcode"""
+        mod = self.mod
+        result = mod.tool_zcode_security_review({"path": "/nonexistent/xyz"})
+        self.assertTrue(result.get("isError"))
+        self.assertIn("不存在", result["content"][0]["text"])
+
     def test_sr3_findings_tmpfile_cleaned(self):
         """SR3: findings 临时文件用后被清理"""
-        mod, saved = self._patch_common()
+        mod, saved, proj = self._patch_common()
         captured = {}
         mod.subprocess.run = lambda cmd, *a, **kw: (
             captured.update(cmd=cmd),
             _FakeCompletedProcess(0, "OK", ""))[1]
         try:
-            mod.tool_zcode_security_review({"path": "/tmp/proj"})
+            mod.tool_zcode_security_review({"path": proj})
         finally:
             self._restore_common(mod, saved)
         attach_path = captured["cmd"][captured["cmd"].index("--attach") + 1]


### PR DESCRIPTION
## 动机

review 体系原用 `--mode plan` 求只读，但 plan 只禁「改文件」：读探索/子代理照样放行（限流与 120s 超时的主因），且 plan→build 的规划惯性容易让 review 变成「边审边修」，与「只出报告」的本意不符。

## 改动

**`zcode_review` 重构（告别 plan）**
- `--mode yolo`（全程免授权）+ `--disallowed-tools` 全量写/执行黑名单（`Write Edit MultiEdit ApplyPatch Bash` + Node REPL 一族 `js`/`mcp__node_repl__js*`——**必须同禁，否则 execSync 可打穿 Bash 黑名单，0.16.1 实测复现**）
- `--disallowed-tools` 是工具集级物理移除、先于权限层，yolo 也绕不过；读工具（Read/Grep/Glob）全开，不影响审查能力
- prompt 内置「只审不修」职责约束作双保险；输出加 `--json` 提取 `response`；单次超时 env `ZCODE_BRIDGE_REVIEW_TIMEOUT`（默认 300s）可配

**新增 `zcode_security_review`（安全专项两阶段管线）**
- ① mimosa 确定性规则引擎快扫（零 LLM 流量，秒级）→ ② findings 回读投影后 `--attach` 喂 zcode 逐条核实（确认/误报/存疑 + 攻击路径 + 修复建议），可发现清单外问题
- mimosa 通过自带极简 stdio MCP client 直 spawn，不依赖 zcode 插件体系；`ZCODE_BRIDGE_MIMOSA_ROOT`/`_TIMEOUT`/`_SCAN_ROOT` 可配

**agent-help 勘误（0.16.1 逆向 + headless 实测）**
- `--allowed-tools`/`--max-turns` 帮助文案有但**未注册 parseArgs**（Unknown option），勿用
- `auto` 模式保留未实现（setMode 切 auto 全拒工具调用）
- headless 下 build/edit 写操作直接报 `No permission client configured` 失败，不是等授权

## 狗食验证（本 PR 由新 review 模式自审）

- **R1 本机 `zcode_review` 审 PR diff**：0 P0 / 2 P1 / 8 P2 → 全部修复或记录（commit `d1047ae`）
- **R2 GC-8G `zcode_security_review` 全仓安全专项**：mimosa 0 findings + zcode 逐文件复核确认 0 漏洞，2 存疑项已评估/加固
- **R3 复审修复 commit**：又抓出 symlink 绕过窗口（P1-A）+ 测试盲区（P1-B）→ 已闭环（commit `8b56992`）
- 端到端实测：GC-8G 安全专项全流程 46.3s（4 个植入漏洞全确认、0 误报、2 条清单外发现）；`zcode_review` 冒烟 51.2s
- 测试：新增 `test_security_review.py` 24 用例；全量 9 个测试文件全绿；ruff 通过

## 不处理项（记录）

- P2-2（posix-only `fcntl`/`select`）与 P2-7（测试 exec 加载模式）为预先存在的模式，不在本 PR
- 复审 P2-2（isdir TOCTOU）/ P2-3（错误上下文含原始行）经评估可接受现状
